### PR TITLE
Changes to make processed amount configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,3 +10,4 @@ jobs:
     uses: killbill/gh-actions-shared/.github/workflows/ci.yml@main
     with:
       test-profile-matrix: '[ "travis"]'
+      failure-upload-path: 'target/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: killbill/gh-actions-shared/.github/workflows/ci.yml@main
+    with:
+      test-profile-matrix: '[ "travis"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,14 @@ name: ci
 
 on:
   push:
+    inputs:
+      jdk-matrix:
+        description: 'jdk matrix as json array'
+        required: false
+        default: '[ "11" ]'  
   pull_request:
   workflow_dispatch:
+
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,13 @@ name: ci
 
 on:
   push:
+  pull_request:
+  workflow_dispatch:
     inputs:
       jdk-matrix:
         description: 'jdk matrix as json array'
         required: false
-        default: '[ "11" ]'  
-  pull_request:
-  workflow_dispatch:
-
+        default: '[ "11" ]'
 
 jobs:
   ci:
@@ -17,3 +16,5 @@ jobs:
     with:
       test-profile-matrix: '[ "travis"]'
       failure-upload-path: 'target/*'
+      jdk-matrix: '[ "11"]'
+   

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,23 @@
+############################################################################################
+#                                                                                          #
+#                   Copyright 2010-2011 Ning, Inc.                                         #
+#                   Copyright 2015 Groupon, Inc                                            #
+#                   Copyright 2022 The Billing Project, LLC                                #
+#                                                                                          #
+#      The Billing Project licenses this file to you under the Apache License, version 2.0 #
+#      (the "License"); you may not use this file except in compliance with the            #
+#      License.  You may obtain a copy of the License at:                                  #
+#                                                                                          #
+#          http://www.apache.org/licenses/LICENSE-2.0                                      #
+#                                                                                          #
+#      Unless required by applicable law or agreed to in writing, software                 #
+#      distributed under the License is distributed on an "AS IS" BASIS, WITHOUT           #
+#      WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the           #
+#      License for the specific language governing permissions and limitations             #
+#      under the License.                                                                  #
+#                                                                                          #
+############################################################################################
+
 language: ruby
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -41,22 +41,24 @@ In that mode, the property `TEST_MODE` must be set to something different than `
 * `THROW_EXCEPTION`=true : This will make the plugin throw RuntimeException exception on each call
 * `RETURN_NIL`=true : This will make the plugin return a nil value on each call
 * `SLEEP_TIME_SEC`=sleep_time_sec : This will make the plugin sleep `sleep_time_sec` on each call
+* `AMOUNT`=amount: This will make the plugin method return the specified amount
 
 ## Global State Configuration
 
 There are cases where it is not possible to pass plugin properties because the payments are made by the system, and the user does not have the opportunity to set plugin properties. For example, when Kill Bill attempts to pay an invoice, it make a `purchasePayment` call without passing plugin properties.
 
-In order to address this scenario it is convenient to configure the plugin to behave a certain way. The plugin can be configured using a private endpoint `/plugins/killbill-payment-test/configure` to either throw exceptions, return nil values or sleep (similar to previous mode). However we also allow to configure which operations should behave that way (the idea is that we may want to make a `purchasePayment` call fail but still allow the `get_payment_info` call to return.
+In order to address this scenario it is convenient to configure the plugin to behave a certain way. The plugin can be configured using a private endpoint `/plugins/killbill-payment-test/configure` to either throw exceptions, return nil values or sleep (similar to previous mode). However we also allow to configure which operations should behave that way (the idea is that we may want to make a `purchasePayment` call fail but still allow the `get_payment_info` call to return. In addition, it is also possible to configure the amount returned by the plugin.
 
 The json body for the call supports the following:
 
-* `CONFIGURE_ACTION`: {`ACTION_THROW_EXCEPTION`|`RETURN_NIL`|`ACTION_SLEEP`|`ACTION_RESET`}
+* `CONFIGURE_ACTION`: {`ACTION_THROW_EXCEPTION`|`RETURN_NIL`|`ACTION_SLEEP`|`ACTION_RETURN_PLUGIN_STATUS_PENDING`|`ACTION_RETURN_PLUGIN_STATUS_ERROR`|`ACTION_RETURN_PLUGIN_STATUS_CANCELED`}
 * `SLEEP_TIME_SEC`: (valid for `CONFIGURE_ACTION` = `ACTION_SLEEP`
-* `METHODS`: The payment plugin api methods for which the configuration apply (or all methods if not specified)
+* `METHODS`: The [PaymentPluginApi]((https://github.com/killbill/killbill-plugin-api/blob/master/payment/src/main/java/org/killbill/billing/payment/plugin/api/PaymentPluginApi.java)) methods for which the configuration apply (or all methods if not specified). Note that the name specified here must match the method name in `PaymentPluginApi`.
+* `AMOUNT` : The amount that the plugin method should return
 
 Examples:
 
-This will confgure the plugin to return an payment error on each `purchasePayment` call (note that the name of the methods come from the definition of the [payment plugin api](https://github.com/killbill/killbill-plugin-api/blob/master/payment/src/main/java/org/killbill/billing/payment/plugin/api/PaymentPluginApi.java):
+To configure the plugin to return a payment error on each `purchasePayment` call you can use:
 
 ```
 curl -v \
@@ -70,7 +72,21 @@ curl -v \
  -v 'http://127.0.0.1:8080/plugins/killbill-payment-test/configure'
 ```
 
-One can clear the state with the following:
+To configure the plugin to return the processed amount as `10` for each `purchasePayment` call you can use:
+
+```
+curl -v \
+-u'admin:password' \
+-H "X-Killbill-ApiKey: bob" \
+-H 'X-Killbill-ApiSecret: lazar' \
+-H "Content-Type: application/json" \
+-H 'X-Killbill-CreatedBy: stephane' \
+-X POST \
+--data-binary '{"METHODS":"purchasePayment", "AMOUNT":"20"}' \
+ -v 'http://127.0.0.1:8080/plugins/killbill-payment-test/configure' 
+ ```
+ 
+To clear the state, you can use:
 
 ```
 curl -v \

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ curl -v \
 -H "Content-Type: application/json" \
 -H 'X-Killbill-CreatedBy: stephane' \
 -X POST \
---data-binary '{"METHODS":"purchasePayment", "AMOUNT":"20"}' \
+--data-binary '{"METHODS":"purchasePayment", "AMOUNT":"10"}' \
  -v 'http://127.0.0.1:8080/plugins/killbill-payment-test/configure' 
  ```
  

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.58</version>
+        <version>0.144.77</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>payment-test-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,6 @@
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-            <!-- 3.14.0 broke returning() on MySQL :( -->
-            <version>3.13.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.58</version>
+        <version>0.144.79</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>payment-test-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.79</version>
+        <version>0.144.84</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>payment-test-plugin</artifactId>
@@ -41,7 +41,6 @@
         <check.fail-spotbugs>true</check.fail-spotbugs>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <osgi.private>org.killbill.billing.plugin.payment.*</osgi.private>
-        <slf4j-api.version>1.7.36</slf4j-api.version>
     </properties>
     <dependencies>
         <dependency>
@@ -87,6 +86,12 @@
             <artifactId>jooq</artifactId>
             <!-- 3.14.0 broke returning() on MySQL :( -->
             <version>3.13.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.kill-bill.billing</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.77</version>
+        <version>0.144.58</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>payment-test-plugin</artifactId>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -19,4 +19,29 @@
     <Match>
         <Class name="~org\.killbill\.billing\.plugin\.payment\.dao\.gen.*"/>
     </Match>
+    <Match>
+        <Class name="org.killbill.billing.plugin.payment.TestingStates"/>
+        <Field name="sleeps"/>
+    </Match> 
+    <Match>
+        <Class name="org.killbill.billing.plugin.payment.TestingStates"/>
+        <Field name="states"/>
+    </Match> 
+    <Match>
+        <Class name="org.killbill.billing.plugin.payment.TestingStates"/>
+        <Field name="amounts"/>
+    </Match>  
+    <Match>
+        <Class name="org.killbill.billing.plugin.payment.resources.PaymentTestResource"/>
+        <Field name="testingStates"/>
+    </Match>
+    <Match>
+        <Class name="org.killbill.billing.plugin.payment.PaymentTestPluginApi"/>
+        <Field name="testingStates"/>
+    </Match>    
+    <Match>
+        <Class name="org.killbill.billing.plugin.payment.PaymentTestPluginApi"/>
+        <Field name="dao"/>
+    </Match>    
+    
 </FindBugsFilter>

--- a/src/main/java/org/killbill/billing/plugin/payment/PaymentTestPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/payment/PaymentTestPluginApi.java
@@ -256,7 +256,7 @@ public class PaymentTestPluginApi extends PluginPaymentPluginApi<TestpaymentResp
         final PaymentPluginStatus pluginStatus = handleState(properties);
         if (pluginStatus != null) {
             final PluginPaymentTransactionInfoPlugin infoPlugin = new PluginPaymentTransactionInfoPlugin(kbPaymentId,
-                                                                                                         kbPaymentMethodId,
+            																							 kbTransactionId,
                                                                                                          TransactionType.AUTHORIZE,
                                                                                                          amount,
                                                                                                          currency,
@@ -286,7 +286,7 @@ public class PaymentTestPluginApi extends PluginPaymentPluginApi<TestpaymentResp
         final PaymentPluginStatus pluginStatus = handleState(properties);
         if (pluginStatus != null) {
             final PluginPaymentTransactionInfoPlugin infoPlugin = new PluginPaymentTransactionInfoPlugin(kbPaymentId,
-                                                                                                         kbPaymentMethodId,
+            																							 kbTransactionId,
                                                                                                          TransactionType.CAPTURE,
                                                                                                          amount,
                                                                                                          currency,
@@ -316,7 +316,7 @@ public class PaymentTestPluginApi extends PluginPaymentPluginApi<TestpaymentResp
         final PaymentPluginStatus pluginStatus = handleState(properties);
         if (pluginStatus != null) {
             final PluginPaymentTransactionInfoPlugin infoPlugin = new PluginPaymentTransactionInfoPlugin(kbPaymentId,
-                                                                                                         kbPaymentMethodId,
+            																							 kbTransactionId,
                                                                                                          TransactionType.PURCHASE,
                                                                                                          amount,
                                                                                                          currency,
@@ -344,7 +344,7 @@ public class PaymentTestPluginApi extends PluginPaymentPluginApi<TestpaymentResp
         final PaymentPluginStatus pluginStatus = handleState(properties);
         if (pluginStatus != null) {
             final PluginPaymentTransactionInfoPlugin infoPlugin = new PluginPaymentTransactionInfoPlugin(kbPaymentId,
-                                                                                                         kbPaymentMethodId,
+            																							 kbTransactionId,
                                                                                                          TransactionType.VOID,
                                                                                                          null,
                                                                                                          null,
@@ -374,7 +374,7 @@ public class PaymentTestPluginApi extends PluginPaymentPluginApi<TestpaymentResp
         final PaymentPluginStatus pluginStatus = handleState(properties);
         if (pluginStatus != null) {
             final PluginPaymentTransactionInfoPlugin infoPlugin = new PluginPaymentTransactionInfoPlugin(kbPaymentId,
-                                                                                                         kbPaymentMethodId,
+            																							 kbTransactionId,
                                                                                                          TransactionType.CREDIT,
                                                                                                          amount,
                                                                                                          currency,
@@ -404,7 +404,7 @@ public class PaymentTestPluginApi extends PluginPaymentPluginApi<TestpaymentResp
         final PaymentPluginStatus pluginStatus = handleState(properties);
         if (pluginStatus != null) {
             final PluginPaymentTransactionInfoPlugin infoPlugin = new PluginPaymentTransactionInfoPlugin(kbPaymentId,
-                                                                                                         kbPaymentMethodId,
+            		     																				 kbTransactionId,
                                                                                                          TransactionType.REFUND,
                                                                                                          null,
                                                                                                          null,

--- a/src/main/java/org/killbill/billing/plugin/payment/PaymentTestPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/payment/PaymentTestPluginApi.java
@@ -255,9 +255,7 @@ public class PaymentTestPluginApi extends PluginPaymentPluginApi<TestpaymentResp
     }
 
 
-    private void insertPaymentResponse(final UUID kbAccountId,
-                                       final UUID tenantId,
-                                       final PluginPaymentTransactionInfoPlugin infoPlugin) throws PaymentPluginApiException {
+    private void insertPaymentResponse(final UUID kbAccountId, final UUID tenantId, final PluginPaymentTransactionInfoPlugin infoPlugin) throws PaymentPluginApiException {
         try {
             this.dao.addPaymentResponse(kbAccountId, tenantId, infoPlugin);
         }

--- a/src/main/java/org/killbill/billing/plugin/payment/PaymentTestPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/payment/PaymentTestPluginApi.java
@@ -145,6 +145,28 @@ public class PaymentTestPluginApi extends PluginPaymentPluginApi<TestpaymentResp
         }
         return sleep;
     }
+    
+    @VisibleForTesting
+    BigDecimal getAmount(final Iterable<PluginProperty> pluginProperties) {
+    	final String methodCalled = Thread.currentThread().getStackTrace()[2].getMethodName();
+        BigDecimal amount = null;
+        if (pluginProperties != null) { 
+        	 // find amount
+        	amount = StreamSupport.stream(pluginProperties.spliterator(), false)
+		              .filter(property -> property.getKey().equals(TestingStates.AMOUNT_PLUGIN_CONFIG_PARAM)) //check for plugin property 
+		              .findFirst().map(property -> new BigDecimal((String)property.getValue())).orElse(null); //get value if property is present
+        	
+        }
+        if (amount == null) {
+            // look for amount in global config
+            final BigDecimal globalAmount = (this.testingStates.getAmounts().get(methodCalled) != null)
+                    ? this.testingStates.getAmounts().get(methodCalled) : this.testingStates.getAmounts().get("*");
+            if (globalAmount != null) { // && globalSleep.compareTo(this.noSleep) > 0
+                amount = globalAmount;
+            }
+        }
+        return amount;
+    }    
 
     private PaymentPluginStatus handleState(final Iterable<PluginProperty> pluginProperties) throws PaymentPluginApiException {
         final String methodCalled = Thread.currentThread().getStackTrace()[2].getMethodName();
@@ -255,10 +277,13 @@ public class PaymentTestPluginApi extends PluginPaymentPluginApi<TestpaymentResp
                                                          final CallContext context) throws PaymentPluginApiException {
         final PaymentPluginStatus pluginStatus = handleState(properties);
         if (pluginStatus != null) {
+        	final BigDecimal configuredAmount = getAmount(properties);
+        	final BigDecimal amountToUse = configuredAmount != null ? configuredAmount : amount;
+        	
             final PluginPaymentTransactionInfoPlugin infoPlugin = new PluginPaymentTransactionInfoPlugin(kbPaymentId,
             																							 kbTransactionId,
                                                                                                          TransactionType.AUTHORIZE,
-                                                                                                         amount,
+                                                                                                         amountToUse,
                                                                                                          currency,
                                                                                                          pluginStatus,
                                                                                                          null,
@@ -285,10 +310,13 @@ public class PaymentTestPluginApi extends PluginPaymentPluginApi<TestpaymentResp
                                                        final CallContext context) throws PaymentPluginApiException {
         final PaymentPluginStatus pluginStatus = handleState(properties);
         if (pluginStatus != null) {
-            final PluginPaymentTransactionInfoPlugin infoPlugin = new PluginPaymentTransactionInfoPlugin(kbPaymentId,
+        	final BigDecimal configuredAmount = getAmount(properties);
+        	final BigDecimal amountToUse = configuredAmount != null ? configuredAmount : amount;        	
+
+        	final PluginPaymentTransactionInfoPlugin infoPlugin = new PluginPaymentTransactionInfoPlugin(kbPaymentId,
             																							 kbTransactionId,
                                                                                                          TransactionType.CAPTURE,
-                                                                                                         amount,
+                                                                                                         amountToUse,
                                                                                                          currency,
                                                                                                          pluginStatus,
                                                                                                          null,
@@ -315,10 +343,13 @@ public class PaymentTestPluginApi extends PluginPaymentPluginApi<TestpaymentResp
                                                         final CallContext context) throws PaymentPluginApiException {
         final PaymentPluginStatus pluginStatus = handleState(properties);
         if (pluginStatus != null) {
+        	final BigDecimal configuredAmount = getAmount(properties);
+        	final BigDecimal amountToUse = configuredAmount != null ? configuredAmount : amount;
+        	
             final PluginPaymentTransactionInfoPlugin infoPlugin = new PluginPaymentTransactionInfoPlugin(kbPaymentId,
             																							 kbTransactionId,
                                                                                                          TransactionType.PURCHASE,
-                                                                                                         amount,
+                                                                                                         amountToUse,
                                                                                                          currency,
                                                                                                          pluginStatus,
                                                                                                          null,
@@ -373,10 +404,13 @@ public class PaymentTestPluginApi extends PluginPaymentPluginApi<TestpaymentResp
                                                       final CallContext context) throws PaymentPluginApiException {
         final PaymentPluginStatus pluginStatus = handleState(properties);
         if (pluginStatus != null) {
+        	final BigDecimal configuredAmount = getAmount(properties);
+        	final BigDecimal amountToUse = configuredAmount != null ? configuredAmount : amount;
+        	
             final PluginPaymentTransactionInfoPlugin infoPlugin = new PluginPaymentTransactionInfoPlugin(kbPaymentId,
             																							 kbTransactionId,
                                                                                                          TransactionType.CREDIT,
-                                                                                                         amount,
+                                                                                                         amountToUse,
                                                                                                          currency,
                                                                                                          pluginStatus,
                                                                                                          null,

--- a/src/main/java/org/killbill/billing/plugin/payment/dao/PaymentTestDao.java
+++ b/src/main/java/org/killbill/billing/plugin/payment/dao/PaymentTestDao.java
@@ -28,6 +28,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.jooq.impl.DSL;
 import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
 import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
@@ -38,6 +39,7 @@ import org.killbill.billing.plugin.payment.dao.gen.tables.TestpaymentResponses;
 import org.killbill.billing.plugin.payment.dao.gen.tables.records.TestpaymentPaymentMethodsRecord;
 import org.killbill.billing.plugin.payment.dao.gen.tables.records.TestpaymentResponsesRecord;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.common.collect.ImmutableList;
 
 import static org.killbill.billing.plugin.payment.dao.gen.tables.TestpaymentPaymentMethods.TESTPAYMENT_PAYMENT_METHODS;
 import static org.killbill.billing.plugin.payment.dao.gen.tables.TestpaymentResponses.TESTPAYMENT_RESPONSES;
@@ -109,7 +111,7 @@ public class PaymentTestDao extends PluginPaymentDao<TestpaymentResponsesRecord,
 															  .toInstant()
 															  .toEpochMilli(), DateTimeZone.UTC),
                                            null, // effective date
-                                           null)) // properties
+                                           ImmutableList.<PluginProperty>of())) // properties
                       .collect(Collectors.toList());
         }
     }

--- a/src/main/java/org/killbill/billing/plugin/payment/dao/PaymentTestDao.java
+++ b/src/main/java/org/killbill/billing/plugin/payment/dao/PaymentTestDao.java
@@ -20,6 +20,7 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -28,7 +29,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.jooq.impl.DSL;
 import org.killbill.billing.catalog.api.Currency;
-import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
 import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
@@ -39,7 +39,6 @@ import org.killbill.billing.plugin.payment.dao.gen.tables.TestpaymentResponses;
 import org.killbill.billing.plugin.payment.dao.gen.tables.records.TestpaymentPaymentMethodsRecord;
 import org.killbill.billing.plugin.payment.dao.gen.tables.records.TestpaymentResponsesRecord;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.google.common.collect.ImmutableList;
 
 import static org.killbill.billing.plugin.payment.dao.gen.tables.TestpaymentPaymentMethods.TESTPAYMENT_PAYMENT_METHODS;
 import static org.killbill.billing.plugin.payment.dao.gen.tables.TestpaymentResponses.TESTPAYMENT_RESPONSES;
@@ -111,7 +110,7 @@ public class PaymentTestDao extends PluginPaymentDao<TestpaymentResponsesRecord,
 															  .toInstant()
 															  .toEpochMilli(), DateTimeZone.UTC),
                                            null, // effective date
-                                           ImmutableList.<PluginProperty>of())) // properties
+                                           Collections.emptyList())) // properties
                       .collect(Collectors.toList());
         }
     }

--- a/src/main/java/org/killbill/billing/plugin/payment/model/Payload.java
+++ b/src/main/java/org/killbill/billing/plugin/payment/model/Payload.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_ABSENT;
 
+import java.math.BigDecimal;
+
 
 @JsonInclude(NON_ABSENT)
 public class Payload {
@@ -29,14 +31,17 @@ public class Payload {
     private final String action;
     private final String methods;
     private final int    sleepTime;
+    private final BigDecimal amount;
 
     @JsonCreator
     public Payload(@JsonProperty("CONFIGURE_ACTION") final String action,
                    @JsonProperty("METHODS") final String methods,
-                   @JsonProperty("SLEEP_TIME_SEC") final int sleepTime) {
+                   @JsonProperty("SLEEP_TIME_SEC") final int sleepTime,
+                   @JsonProperty("AMOUNT") final BigDecimal amount) {
         this.action = action;
         this.methods = methods;
         this.sleepTime = sleepTime;
+        this.amount = amount;
     }
 
     public String getAction() {
@@ -45,7 +50,11 @@ public class Payload {
 
     public String getMethods() { return this.methods;}
 
-    public int getSeepTime() {
+    public int getSleepTime() {
         return this.sleepTime;
     }
+    
+    public BigDecimal getAmount() {
+        return this.amount;
+    }    
 }

--- a/src/main/java/org/killbill/billing/plugin/payment/resources/PaymentTestResource.java
+++ b/src/main/java/org/killbill/billing/plugin/payment/resources/PaymentTestResource.java
@@ -51,15 +51,17 @@ public class PaymentTestResource {
     public Result configure(@Body final Payload payload) {
 
         final boolean added;
-
-        if (payload.getSeepTime() != 0) {
-            added = this.testingStates.add(TestingStates.Actions.valueOf(payload.getAction()),
-                                           payload.getMethods(),
-                                           payload.getSeepTime());
-        }
-        else {
-            added = this.testingStates.add(TestingStates.Actions.valueOf(payload.getAction()),
-                                           payload.getMethods());
+        final TestingStates.Actions action = payload.getAction() != null ? TestingStates.Actions.valueOf(payload.getAction()) : null;
+        
+        if (payload.getSleepTime() == 0 && payload.getAmount() == null) {
+        	 added = this.testingStates.add(action,
+                     payload.getMethods());
+        } else {
+        	
+        	added = this.testingStates.add(action, 
+					   payload.getMethods(), 
+					   payload.getSleepTime(),
+					   payload.getAmount());
         }
 
         if (!added) {

--- a/src/test/java/org/killbill/billing/plugin/payment/PaymentTestPluginApiDBTest.java
+++ b/src/test/java/org/killbill/billing/plugin/payment/PaymentTestPluginApiDBTest.java
@@ -97,11 +97,12 @@ public class PaymentTestPluginApiDBTest {
         final UUID kbPaymentId = UUID.randomUUID();
         //        final UUID kbTransactionId = UUID.randomUUID();
         final UUID kbPaymentMethodId = UUID.randomUUID();
+        final UUID kbTransactionId = UUID.randomUUID();
 
         final PaymentTransactionInfoPlugin ret = this.paymentTestPugin.authorizePayment(
                 this.accountId,
                 kbPaymentId,
-                UUID.randomUUID(),
+                kbTransactionId,
                 kbPaymentMethodId,
                 BigDecimal.TEN,
                 Currency.EUR,
@@ -116,7 +117,7 @@ public class PaymentTestPluginApiDBTest {
                                                         kbPaymentId);
         Assert.assertEquals(responses.size(), 1);
 		Assert.assertEquals(responses.get(0).getKbPaymentId().compareTo(kbPaymentId), 0);
-		Assert.assertEquals(responses.get(0).getKbTransactionPaymentId().compareTo(kbPaymentMethodId), 0);
+		Assert.assertEquals(responses.get(0).getKbTransactionPaymentId().compareTo(kbTransactionId), 0);
 		Assert.assertEquals(responses.get(0).getAmount().compareTo(BigDecimal.TEN), 0);
         Assert.assertEquals(responses.get(0).getCurrency(), Currency.EUR);
     }

--- a/src/test/java/org/killbill/billing/plugin/payment/PaymentTestPluginApiTest.java
+++ b/src/test/java/org/killbill/billing/plugin/payment/PaymentTestPluginApiTest.java
@@ -179,6 +179,51 @@ public class PaymentTestPluginApiTest {
                 this.pluginCallContext);
         Assert.assertEquals(ret.getStatus(), PaymentPluginStatus.ERROR);
     }
+    
+    @Test
+    public void setAmount() throws PaymentPluginApiException {
+        this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_PENDING, "purchasePayment", 0, BigDecimal.ONE);
+        this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_CANCELED, "capturePayment");
+        this.testingStates.add(null, "authorizePayment",0, BigDecimal.ONE);
+
+        PaymentTransactionInfoPlugin ret = this.paymentTestPugin.purchasePayment(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                BigDecimal.TEN,
+                Currency.EUR,
+                null,
+                this.pluginCallContext);
+        Assert.assertEquals(ret.getStatus(), PaymentPluginStatus.PENDING);
+        Assert.assertEquals(ret.getAmount().compareTo(BigDecimal.ONE), 0);
+
+        ret = this.paymentTestPugin.capturePayment(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                BigDecimal.TEN,
+                Currency.EUR,
+                null,
+                this.pluginCallContext);
+        Assert.assertEquals(ret.getStatus(), PaymentPluginStatus.CANCELED);
+        Assert.assertEquals(ret.getAmount().compareTo(BigDecimal.TEN), 0);
+        
+        ret = this.paymentTestPugin.authorizePayment(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                BigDecimal.TEN,
+                Currency.EUR,
+                null,
+                this.pluginCallContext);
+        Assert.assertEquals(ret.getStatus(), PaymentPluginStatus.PROCESSED);
+        Assert.assertEquals(ret.getAmount().compareTo(BigDecimal.ONE), 0);        
+    }    
+    
+ 
 
     @Test
     public void methodOverrideWildCard() throws PaymentPluginApiException {
@@ -312,8 +357,8 @@ public class PaymentTestPluginApiTest {
 
     @Test
     public void sleepMethodOverrideWildCard() {
-        this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_PENDING, "authorizePayment", 15);
-        this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_PENDING, null, 60);
+        this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_PENDING, "authorizePayment", 15, null);
+        this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_PENDING, null, 60, null);
         Assert.assertEquals(this.paymentTestPugin.getSleepValue("authorizePayment", null), 15);
 
     }
@@ -337,19 +382,19 @@ public class PaymentTestPluginApiTest {
 
     @Test
     public void sleepFromGlobalConfig() {
-        this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_PENDING, "authorizePayment", 15);
+        this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_PENDING, "authorizePayment", 15, null);
         Assert.assertEquals(this.paymentTestPugin.getSleepValue("authorizePayment", null), 15);
     }
 
     @Test
     public void wildcardSleepFromGlobalConfig() {
-        this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_PENDING, null, 15);
+        this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_PENDING, null, 15, null);
         Assert.assertEquals(this.paymentTestPugin.getSleepValue("authorizePayment", null), 15);
     }
 
     @Test
     public void sleepFromConfigOverrideGlobal() {
-        this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_PENDING, "authorizePayment", 15);
+        this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_PENDING, "authorizePayment", 15, null);
 
         final ImmutableList<PluginProperty> properties = ImmutableList.of(
                 new PluginProperty(TestingStates.Actions.ACTION_SLEEP.toString(), "authorizePayment", false),

--- a/src/test/java/org/killbill/billing/plugin/payment/TestingStatesTest.java
+++ b/src/test/java/org/killbill/billing/plugin/payment/TestingStatesTest.java
@@ -17,24 +17,86 @@
 package org.killbill.billing.plugin.payment;
 
 
+import java.math.BigDecimal;
+
 import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class TestingStatesTest {
 
     private final TestingStates testingStates = new TestingStates();
+    
+    @BeforeMethod
+    void clearAll(){
+    	Assert.assertTrue(this.testingStates.add(TestingStates.Actions.ACTION_CLEAR, null));
+    }
 
     @Test
     void testAddKnownMethod() {
 		Assert.assertTrue(this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_CANCELED,
 												 "authorizePayment"));
     }
-
+    
+    @Test
+    void testAddSleepTimeOnly() {
+		Assert.assertTrue(this.testingStates.add(null,"authorizePayment", 60, null));
+		
+		Assert.assertEquals(this.testingStates.getSleeps().get("authorizePayment").compareTo(60), 0);
+		Assert.assertNull(this.testingStates.getStates().get("authorizePayment"));
+		Assert.assertNull(this.testingStates.getAmounts().get("authorizePayment"));
+		
+    }    
+    
+    @Test
+    void testAddAmountOnlyWithoutMethodName() {
+		Assert.assertTrue(this.testingStates.add(null, null, 0, BigDecimal.TEN));
+		
+		Assert.assertNull(this.testingStates.getSleeps().get("authorizePayment"));
+		Assert.assertNull(this.testingStates.getStates().get("authorizePayment"));
+		Assert.assertNull(this.testingStates.getAmounts().get("authorizePayment"));
+		Assert.assertEquals(this.testingStates.getAmounts().get("*").compareTo(BigDecimal.TEN),0);
+    }     
+    
+    @Test
+    void testAddSleepTimeAndAmountWithoutState() {
+		Assert.assertTrue(this.testingStates.add(null,
+												  "authorizePayment", 60, BigDecimal.TEN));
+		
+		Assert.assertEquals(this.testingStates.getSleeps().get("authorizePayment").compareTo(60), 0);
+		Assert.assertEquals(this.testingStates.getAmounts().get("authorizePayment").compareTo(BigDecimal.TEN),0);
+		Assert.assertNull(this.testingStates.getStates().get("authorizePayment"));
+		
+    }     
+    
+    @Test
+    void testAddSleepTimeAndStateWithoutAmount() {
+		Assert.assertTrue(this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_CANCELED,
+												  "authorizePayment", 60, null));
+		
+		Assert.assertEquals(this.testingStates.getStates().get("authorizePayment").compareTo(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_CANCELED), 0);
+		Assert.assertEquals(this.testingStates.getSleeps().get("authorizePayment").compareTo(60), 0);
+		Assert.assertNull(this.testingStates.getAmounts().get("authorizePayment"));
+		
+    }   
+    
+    @Test
+    void testAddAmountSleepTimeAndState() {
+		Assert.assertTrue(this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_CANCELED, "authorizePayment", 60, BigDecimal.TEN));
+		
+		Assert.assertEquals(this.testingStates.getStates().get("authorizePayment").compareTo(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_CANCELED), 0);
+		Assert.assertEquals(this.testingStates.getSleeps().get("authorizePayment").compareTo(60), 0);
+		Assert.assertEquals(this.testingStates.getAmounts().get("authorizePayment").compareTo(BigDecimal.TEN),0);
+		
+    }    
+ 
     @Test
     void testAddUnknownMethod() {
 		Assert.assertFalse(this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_CANCELED,
 												  "dummy"));
     }
+    
+  
 
     @Test
     void clearAllStates() {
@@ -43,10 +105,10 @@ public class TestingStatesTest {
 		Assert.assertTrue(this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_CANCELED,
 												 "capturePayment"));
 		Assert.assertTrue(this.testingStates.add(TestingStates.Actions.ACTION_RETURN_PLUGIN_STATUS_CANCELED,
-												 "voidPayment", 60));
+												 "voidPayment", 60, null));
 
         Assert.assertEquals(this.testingStates.getSleeps().size(), 1);
-        Assert.assertEquals(this.testingStates.getStates().size(), 2);
+        Assert.assertEquals(this.testingStates.getStates().size(), 3);
 
 
 		Assert.assertTrue(this.testingStates.add(TestingStates.Actions.ACTION_CLEAR, null));

--- a/src/test/java/org/killbill/billing/plugin/payment/model/PayloadTest.java
+++ b/src/test/java/org/killbill/billing/plugin/payment/model/PayloadTest.java
@@ -22,6 +22,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 
 public class PayloadTest {
 
@@ -35,7 +36,9 @@ public class PayloadTest {
         final Payload payload = objectMapper.readValue(json, Payload.class);
 
         Assert.assertEquals("action", payload.getAction());
-        Assert.assertEquals(13, payload.getSeepTime());
+        Assert.assertEquals(13, payload.getSleepTime());
+        Assert.assertNull(payload.getAmount());
+        Assert.assertNull(payload.getMethods());
     }
 
     @Test
@@ -49,5 +52,35 @@ public class PayloadTest {
 
         Assert.assertEquals("action", payload.getAction());
     }
+    
+    @Test
+    public void testAmount() throws IOException {
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+
+        final String json = "{\"CONFIGURE_ACTION\":\"action\", \"AMOUNT\": 10}";
+
+        final Payload payload = objectMapper.readValue(json, Payload.class);
+
+        Assert.assertEquals("action", payload.getAction());
+        Assert.assertEquals(payload.getAmount().compareTo(BigDecimal.TEN), 0);
+        Assert.assertEquals(payload.getSleepTime(), 0);
+        Assert.assertNull(payload.getMethods());
+    }    
+    
+    @Test
+    public void testMethodAndAmount() throws IOException {
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+
+        final String json = "{\"METHODS\":\"purchasePayment\", \"AMOUNT\": 10}";
+
+        final Payload payload = objectMapper.readValue(json, Payload.class);
+        
+        Assert.assertEquals(payload.getAmount().compareTo(BigDecimal.TEN), 0);
+        Assert.assertEquals("purchasePayment", payload.getMethods());
+        Assert.assertEquals(payload.getSleepTime(), 0);
+        Assert.assertNull(payload.getAction());
+    }      
 
 }


### PR DESCRIPTION
- Changes to make processed amount configurable. 
- Some bug fixes (`paymentMethodId` was used while creating the `PluginPaymentTransactionInfoPlugin` instead of `kbTransactionId`).